### PR TITLE
protect csv columns with quotation marks

### DIFF
--- a/src/index.js.patch
+++ b/src/index.js.patch
@@ -27,7 +27,7 @@ index d7b31ce..ba68c99 100644
  ];
  
 -console.log('CATEGORY\t\tPLUGIN\t\t\t\tTEST\t\t\t\tRESOURCE\t\t\tREGION\t\tSTATUS\tMESSAGE');
-+console.log('CATEGORY,PLUGIN,TEST,RESOURCE,REGION,STATUS,MESSAGE');
++console.log('"CATEGORY","PLUGIN","TEST","RESOURCE","REGION","STATUS","MESSAGE"');
  
  async.eachSeries(plugins, function(pluginPath, callback){
      var plugin = require(__dirname + '/plugins/' + pluginPath);
@@ -36,7 +36,7 @@ index d7b31ce..ba68c99 100644
                      statusWord = 'UNKNOWN';
                  }
 -                console.log(result.category + '\t\t' + result.title + '\t' + result.tests[i].title + '\t' + (result.tests[i].results[j].resource || 'N/A') + '\t' + (result.tests[i].results[j].region || 'Global') + '\t\t' + statusWord + '\t' + result.tests[i].results[j].message);
-+                console.log(result.category + ',' + result.title + ',' + result.tests[i].title + ',' + (result.tests[i].results[j].resource || 'N/A') + ',' + (result.tests[i].results[j].region || 'Global') + ',' + statusWord + ',' + result.tests[i].results[j].message);
++                console.log('"' + result.category + '","' + result.title + '","' + result.tests[i].title + '","' + (result.tests[i].results[j].resource || 'N/A') + '","' + (result.tests[i].results[j].region || 'Global') + '","' + statusWord + '","' + result.tests[i].results[j].message + '"');
              }
          }
          callback(err);


### PR DESCRIPTION
It turns out the scanner can put commas into its output, so
we need to protect it with quotation marks.

Example for one column:

```
Bucket: <redacted> allows global access to: READ_ACP,WRITE_ACP,,
```
