### PR TITLE
upgrade to current upstream cloudsploit version

### DIFF
--- a/src/index.js.patch
+++ b/src/index.js.patch
@@ -1,23 +1,18 @@
 diff --git a/index.js b/index.js
-index d7b31ce..948f4db 100644
+index 8c667c0..7944fc8 100644
 --- a/index.js
 +++ b/index.js
-@@ -1,13 +1,18 @@
+@@ -1,12 +1,14 @@
  var async = require('async');
 +var proxy = require('proxy-agent');
  
+ // OPTION 1: Configure AWS credentials through hard-coded key and secret
 -// var AWSConfig = {
 -//     accessKeyId: '',
 -//     secretAccessKey: '',
 -//     sessionToken: '',
 -//     region: 'us-east-1'
 -// };
-+var proxy_map = {};
-+if (process.env.PROXY) {
-+  proxy_map = { agent: proxy(process.env.PROXY) };
-+}
- 
--var AWSConfig = require(__dirname + '/../../cloudsploit-secure/scan-test-credentials.json');
 +var AWSConfig = {
 +    httpOptions: proxy_map,
 +    accessKeyId: process.env.AWS_ACCESS_KEY_ID,
@@ -26,9 +21,9 @@ index d7b31ce..948f4db 100644
 +    region: process.env.AWS_DEFAULT_REGION
 +};
  
- var plugins = [
-     'iam/rootAccountSecurity.js',
-@@ -27,7 +32,7 @@ var plugins = [
+ // OPTION 2: Import an AWS config file containing credentials
+ // var AWSConfig = require(__dirname + '/credentials.json');
+@@ -32,7 +34,7 @@ var plugins = [
      'rds/databaseSecurity.js'
  ];
  
@@ -37,7 +32,7 @@ index d7b31ce..948f4db 100644
  
  async.eachSeries(plugins, function(pluginPath, callback){
      var plugin = require(__dirname + '/plugins/' + pluginPath);
-@@ -46,7 +51,7 @@ async.eachSeries(plugins, function(pluginPath, callback){
+@@ -51,7 +53,7 @@ async.eachSeries(plugins, function(pluginPath, callback){
                  } else {
                      statusWord = 'UNKNOWN';
                  }


### PR DESCRIPTION
changes from upstream:
- removing credentials file import line as a default, fixes #23
- simplifying lambda function, adding readme docs, fixes #24
- adding ssh key audit check
- adding new ssh plugin to exports
